### PR TITLE
Fixed Terraform Module

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,6 +24,7 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-duration-seconds: 1200
           aws-region: ap-southeast-2
       
       - name: Build AWS AMI for Pritunl VM Image

--- a/terraform/ci/main.tf
+++ b/terraform/ci/main.tf
@@ -22,7 +22,7 @@ data "aws_iam_policy_document" "assume_role_policy" {
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root",
         "arn:aws:iam::${data.aws_caller_identity.current.account_id}:${var.svc_packer_role_name}"
       ]
     }
@@ -35,11 +35,11 @@ data "aws_iam_policy_document" "assume_role_policy" {
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root",
         "arn:aws:iam::${data.aws_caller_identity.current.account_id}:${var.svc_packer_role_name}"
       ]
     }
-    
+
   }
   // Allow users in management acount to assume this role.
   statement {
@@ -210,8 +210,8 @@ module "iam_group_with_policies" {
 
 module "iam_policy_assume_role" {
   source = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  name        = var.service_group_name
-  path        = "/"
+  name   = var.service_group_name
+  path   = "/"
   policy = data.aws_iam_policy_document.assume_service_role.json
 }
 

--- a/terraform/ci/main.tf
+++ b/terraform/ci/main.tf
@@ -23,7 +23,7 @@ data "aws_iam_policy_document" "assume_role_policy" {
       type = "AWS"
       identifiers = [
         "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root",
-        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:${var.svc_packer_role_name}"
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:${var.svc_packer_role_name.name}"
       ]
     }
   }
@@ -36,7 +36,7 @@ data "aws_iam_policy_document" "assume_role_policy" {
       type = "AWS"
       identifiers = [
         "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root",
-        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:${var.svc_packer_role_name}"
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:${var.svc_packer_role_name.name}"
       ]
     }
 

--- a/terraform/ci/main.tf
+++ b/terraform/ci/main.tf
@@ -16,16 +16,32 @@ data "aws_caller_identity" "current" {}
 
 data "aws_iam_policy_document" "assume_role_policy" {
   statement {
+    sid     = "AllowAssumeRole"
     actions = ["sts:AssumeRole"]
 
     principals {
       type = "AWS"
       identifiers = [
         "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:${var.svc_packer_role_name}"
       ]
     }
   }
-  // Allow users in root acount to assume this role.
+  // Required for GitHub actions to assume role :)))
+  statement {
+    sid     = "AllowPassSessionTags"
+    actions = ["sts:TagSession"]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:${var.svc_packer_role_name}"
+      ]
+    }
+    
+  }
+  // Allow users in management acount to assume this role.
   statement {
     actions = ["sts:AssumeRole"]
     principals {
@@ -205,7 +221,6 @@ data "aws_iam_policy_document" "assume_service_role" {
       "sts:AssumeRole",
       "sts:TagSession"
     ]
-
     resources = [aws_iam_role.service_role.arn]
   }
 }

--- a/terraform/ci/main.tf
+++ b/terraform/ci/main.tf
@@ -23,7 +23,7 @@ data "aws_iam_policy_document" "assume_role_policy" {
       type = "AWS"
       identifiers = [
         "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root",
-        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:${var.service_user_name}"
+        module.service_user.iam_user_arn
       ]
     }
   }
@@ -36,7 +36,7 @@ data "aws_iam_policy_document" "assume_role_policy" {
       type = "AWS"
       identifiers = [
         "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root",
-        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:${var.service_user_name}"
+        module.service_user.iam_user_arn   
       ]
     }
 

--- a/terraform/ci/main.tf
+++ b/terraform/ci/main.tf
@@ -196,7 +196,7 @@ module "iam_policy_assume_role" {
   source = "terraform-aws-modules/iam/aws//modules/iam-policy"
   name        = var.service_group_name
   path        = "/"
-  policy = data.aws_iam_policy_document.assume_service_role
+  policy = data.aws_iam_policy_document.assume_service_role.json
 }
 
 data "aws_iam_policy_document" "assume_service_role" {

--- a/terraform/ci/main.tf
+++ b/terraform/ci/main.tf
@@ -190,12 +190,6 @@ module "iam_group_with_policies" {
   attach_iam_self_management_policy = false
 
   custom_group_policy_arns = module.iam_policy_assume_role.arn
-  custom_group_policies = [
-    {
-      name   = "AllowS3Listing"
-      policy = data.aws_iam_policy_document.sample.json
-    }
-  ]
 }
 
 module "iam_policy_assume_role" {

--- a/terraform/ci/main.tf
+++ b/terraform/ci/main.tf
@@ -23,7 +23,7 @@ data "aws_iam_policy_document" "assume_role_policy" {
       type = "AWS"
       identifiers = [
         "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root",
-        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:${var.svc_packer_role_name.name}"
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:${var.service_user_name}"
       ]
     }
   }
@@ -36,7 +36,7 @@ data "aws_iam_policy_document" "assume_role_policy" {
       type = "AWS"
       identifiers = [
         "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root",
-        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:${var.svc_packer_role_name.name}"
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:${var.service_user_name}"
       ]
     }
 

--- a/terraform/ci/main.tf
+++ b/terraform/ci/main.tf
@@ -185,11 +185,11 @@ module "iam_group_with_policies" {
 
   name = var.service_group_name
 
-  group_users = module.service_user.iam_user_name
+  group_users = [module.service_user.iam_user_name]
 
   attach_iam_self_management_policy = false
 
-  custom_group_policy_arns = module.iam_policy_assume_role.arn
+  custom_group_policy_arns = [module.iam_policy_assume_role.arn]
 }
 
 module "iam_policy_assume_role" {


### PR DESCRIPTION
Updated 'terraform/ci' module to assign correct permissions in role trust policy to allow GitHub Actions to assume the role.